### PR TITLE
Apply the trits convertion for expected output neuron value.

### DIFF
--- a/src/Qiner.cpp
+++ b/src/Qiner.cpp
@@ -788,7 +788,8 @@ struct Miner
                 neuronValue = -1;
             }
 
-            outputNeuronExpectedValue[i] = neuronValue;
+            // Convert value of neuron to trits (keeping 1 as 1, and changing 0 to -1.).
+            outputNeuronExpectedValue[i] = (neuronValue == 0) ? -1 : neuronValue;
         }
     }
 


### PR DESCRIPTION
This PR fix issue relate to uneven probability when expected output neuron value has zero value.